### PR TITLE
remove sort-keys rule

### DIFF
--- a/packages/eslint-config-js/.eslintrc.json
+++ b/packages/eslint-config-js/.eslintrc.json
@@ -36,7 +36,6 @@
     "require-atomic-updates": ["error", {
       "allowProperties": true
     }],
-    "sort-keys": "error",
     "import/default": "error",
     "import/named": "error",
     "import/no-cycle": ["error", {


### PR DESCRIPTION
In a perfect world I would love us to have sorted keys but unless there's a way we can agree to have them automatically sorted it's a lot of work to fix in an existing code base. It's not clear how well auto fixing plugins deal with comments. 

So if we can work out how to we should have this. Seems like a rule that will cause significant friction on day 1 though (for existing projects in any case)