### PR TITLE
feat: add @autotelic/eslint-config-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@autotelic/lint-configs",
   "scripts": {
     "bootstrap": "lerna bootstrap --strict",
-    "clean": "lerna clean -y && lerna exec -- rm -f package-lock.json",
+    "clean": "lerna clean -y && lerna exec -- rm -f package-lock.json && rm -rf package-lock.json node_modules",
     "validate": "lerna run lint",
     "version:bump": "lerna version --conventional-commits --create-release github",
     "version:release": "lerna publish from-package"

--- a/packages/eslint-config-js/README.md
+++ b/packages/eslint-config-js/README.md
@@ -1,6 +1,6 @@
 # Autotelic - Eslint Config JS
 
-*Base [Eslint](https://eslint.org/docs/latest/) configuration for any JavaScript application*
+*Autotelic's base [Eslint](https://eslint.org/docs/latest/) configuration for any JavaScript application*
 
 ### Usage
 

--- a/packages/eslint-config-react/.eslintrc.json
+++ b/packages/eslint-config-react/.eslintrc.json
@@ -13,8 +13,7 @@
   },
   "rules": {
     "react/function-component-definition": ["error", {
-      "namedComponents": ["function-declaration", "arrow-function"],
-      "unnamedComponents": "arrow-function"
+      "namedComponents": ["function-declaration", "arrow-function"]
     }],
     "react/jsx-boolean-value": ["error", "always"],
     "react/jsx-closing-bracket-location": "error",
@@ -98,6 +97,6 @@
     "react/style-prop-object": "error",
     "react/void-dom-elements-no-children": "error",
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "error"
   }
 }

--- a/packages/eslint-config-react/.eslintrc.json
+++ b/packages/eslint-config-react/.eslintrc.json
@@ -1,0 +1,103 @@
+{
+  "extends": ["@autotelic/eslint-config-js"],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "plugins": ["react", "react-hooks"],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "rules": {
+    "react/function-component-definition": ["error", {
+      "namedComponents": ["function-declaration", "arrow-function"],
+      "unnamedComponents": "arrow-function"
+    }],
+    "react/jsx-boolean-value": ["error", "always"],
+    "react/jsx-closing-bracket-location": "error",
+    "react/jsx-closing-tag-location": "error",
+    "react/jsx-curly-brace-presence": ["error", {
+      "props": "never",
+      "children": "never",
+      "propElementValues": "always"
+    }],
+    "react/jsx-curly-newline": ["error", "consistent"],
+    "react/jsx-curly-spacing": ["error", { "when": "never", "children": true }],
+    "react/jsx-equals-spacing": ["error", "never"],
+    "react/jsx-first-prop-new-line": ["error", "multiline"],
+    "react/jsx-fragments": ["error", "syntax"],
+    "react/jsx-indent": ["error", 2, { "checkAttributes": true, "indentLogicalExpressions": true }],
+    "react/jsx-indent-props": ["error", 2],
+    "react/jsx-key": "error",
+    "react/jsx-max-props-per-line": ["error", { "maximum": { "single": 5, "multi": 1 } }],
+    "react/jsx-newline": ["error", { "prevent": true }],
+    "react/jsx-no-bind": ["error", {
+      "allowArrowFunctions": true,
+      "allowBind": false,
+      "ignoreRefs": true
+    }],
+    "react/jsx-no-comment-textnodes": "error",
+    "react/jsx-no-constructed-context-values": "error",
+    "react/jsx-no-duplicate-props": "error",
+    "react/jsx-no-leaked-render": ["error", { "validStrategies": ["ternary"] }],
+    "react/jsx-no-undef": ["error", { "allowGlobals": true }],
+    "react/jsx-no-useless-fragment": ["error", { "allowExpressions": true }],
+    "react/jsx-one-expression-per-line": ["error", { "allow": "literal" }],
+    "react/jsx-pascal-case": "error",
+    "react/jsx-sort-props": ["error", {
+      "callbacksLast": true,
+      "shorthandLast": true,
+      "multiline": "last",
+      "ignoreCase": true,
+      "reservedFirst": true
+    }],
+    "react/jsx-tag-spacing": ["error", {
+      "closingSlash": "never",
+      "beforeSelfClosing": "always",
+      "afterOpening": "never",
+      "beforeClosing": "never"
+    }],
+    "react/jsx-uses-react": "error",
+    "react/jsx-uses-vars": "error",
+    "react/jsx-wrap-multilines": ["error", {
+      "declaration": "parens-new-line",
+      "assignment": "parens-new-line",
+      "return": "parens-new-line",
+      "arrow": "parens-new-line",
+      "condition": "parens-new-line",
+      "logical": "parens-new-line",
+      "prop": "parens-new-line"
+    }],
+    "react/no-deprecated": "warn",
+    "react/no-did-update-set-state": "error",
+    "react/no-direct-mutation-state": "error",
+    "react/no-find-dom-node": "error",
+    "react/no-invalid-html-attribute": "error",
+    "react/no-is-mounted": "error",
+    "react/no-object-type-as-default-prop": "error",
+    "react/no-string-refs": "error",
+    "react/no-this-in-sfc": "error",
+    "react/no-unescaped-entities": "error",
+    "react/no-unknown-property": "error",
+    "react/no-unstable-nested-components": "error",
+    "react/no-unused-class-component-methods": "error",
+    "react/no-unused-state": "error",
+    "react/no-will-update-set-state": "error",
+    "react/prefer-es6-class": "error",
+    "react/prefer-stateless-function": "error",
+    "react/react-in-jsx-scope": "error",
+    "react/require-render-return": "error",
+    "react/self-closing-comp": ["error", {
+      "component": true,
+      "html": true
+    }],
+    "react/sort-comp": "error",
+    "react/style-prop-object": "error",
+    "react/void-dom-elements-no-children": "error",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
+  }
+}

--- a/packages/eslint-config-react/.eslintrc.json
+++ b/packages/eslint-config-react/.eslintrc.json
@@ -87,7 +87,6 @@
     "react/no-will-update-set-state": "error",
     "react/prefer-es6-class": "error",
     "react/prefer-stateless-function": "error",
-    "react/react-in-jsx-scope": "error",
     "react/require-render-return": "error",
     "react/self-closing-comp": ["error", {
       "component": true,

--- a/packages/eslint-config-react/LICENSE
+++ b/packages/eslint-config-react/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 autotelic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/eslint-config-react/README.md
+++ b/packages/eslint-config-react/README.md
@@ -1,0 +1,40 @@
+# Autotelic - Eslint Config React
+
+*Autotelic's base [Eslint](https://eslint.org/docs/latest/) configuration for any React application*
+
+### Usage
+
+Thanks to [`@rushstack/eslint-patch`](https://github.com/microsoft/rushstack/tree/main/eslint/eslint-patch#readme), this package has no peer dependencies other than `eslint`. To use `@autotelic/eslint-config-react` in your project, just run one of the following install commands and add the `.eslintrc.json` suggested below.
+
+#### NPM
+
+```sh
+npm i --save-dev eslint @autotelic/eslint-config-react
+```
+
+#### Yarn
+
+```sh
+yarn add --dev eslint @autotelic/eslint-config-react
+```
+
+#### `.eslintrc.json`
+
+```json
+{
+  "extends": ["@autotelic/eslint-config-react"],
+  "settings": {
+    "node": {
+      "version": "^18.x", // Any Node version >= 16
+    }
+  }
+}
+```
+
+### About
+
+`@autotelic/eslint-config-react` is comprised with a combination of:
+
+  - [`@autotelic/eslint-config-js`](https://github.com/autotelic/lint-configs/tree/main/packages/eslint-config-js#readme)
+  - [`eslint-plugin-react`](https://github.com/jsx-eslint/eslint-plugin-react#readme)
+  - [`eslint-plugin-react-hooks`](https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks#readme)

--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -1,0 +1,3 @@
+require('@rushstack/eslint-patch/modern-module-resolution')
+
+module.exports = require('./.eslintrc.json')

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@autotelic/eslint-config-react",
+  "version": "0.0.0",
+  "description": "base eslint config for react apps",
+  "main": "index.js",
+  "files": [
+    ".eslintrc.json"
+  ],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint ."
+  },
+  "keywords": [
+    "eslint",
+    "eslint-config",
+    "javascript",
+    "js",
+    "jsx",
+    "lint",
+    "react",
+    "standard"
+  ],
+  "author": "Holden Whitehead (holden@autotelic.com)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/autotelic/lint-configs.git",
+    "directory": "packages/eslint-config-react"
+  },
+  "homepage": "https://github.com/autotelic/lint-configs/tree/main/packages/eslint-config-react",
+  "license": "MIT",
+  "dependencies": {
+    "@autotelic/eslint-config-js": "^0.1.1",
+    "@rushstack/eslint-patch": "^1.2.0",
+    "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.0"
+  },
+  "devDependencies": {
+    "eslint": "^8.36.0"
+  },
+  "peerDependencies": {
+    "eslint": "^8.0.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
### Summary
 - Adds `@autotelic/eslint-config-react`

### Test Plan
 - Install [yalc](https://github.com/wclr/yalc) (If not already done)
 - Checkout this branch and `cd packages/eslint-config-react`
 - Run `yalc publish`
 - Add lint config to a react project `yalc add --dev @autotelic/eslint-config-react` (you may need to re-install deps after)
 - Update project's `.eslintrc.json`
   ```json
   {
     "extends": ["@autotelic/eslint-config-react"],
     "settings": {
       "node": {
         "version": "^18.x",
       }
     }
   }
   ```
 - Run lint
 - Share opinions